### PR TITLE
fix li styles

### DIFF
--- a/theme/assets/css/main.css
+++ b/theme/assets/css/main.css
@@ -24,9 +24,13 @@ a { color: #18447d; }
 a:hover { color: #12345f; }
 a:focus { color: #12345f; }
 
-p {
+p, li {
   font-size: 17px;
   line-height: 1.4;
+}
+
+li {
+  margin-bottom: 5px;
 }
 
 img {


### PR DESCRIPTION
o(*>ω<*)o

i was drafting the new blog post and noticed our `li` styles are not correct. before on left, after on right.

<img width="1611" alt="Screen Shot 2020-02-09 at 3 23 53 PM" src="https://user-images.githubusercontent.com/5498072/74112309-54c6c100-4b50-11ea-8427-a8dddc975904.png">
