### PR TITLE
fix(css): set img width/height to auto

### DIFF
--- a/theme/assets/css/main.css
+++ b/theme/assets/css/main.css
@@ -34,7 +34,9 @@ li {
 }
 
 img {
+  height: auto;
   max-width: 100%;
+  width: auto;
 }
 
 kbd {


### PR DESCRIPTION
### what

in newer versions of ghost, explicit width/height attributes are set on our images, which makes them look bad. this overrides them and fixes the scaling